### PR TITLE
translate home into german and catalan on navmenue

### DIFF
--- a/src/components/NavMenu.vue
+++ b/src/components/NavMenu.vue
@@ -125,11 +125,11 @@ en:
   about: "About us"
   calendar: "Calendar"
 de:
-  home: "Home"
+  home: "Startseite"
   about: "Über uns"
   calendar: "Kalender"
 ca:
-  home: "Home"
+  home: "Inici"
   about: "Qui som"
   calendar: "Calendari"
 </i18n>


### PR DESCRIPTION
"Home" is also displayed in Catalan and German an it sounds really weird (especially in Catalan, since "home" has a meaning of it's own).